### PR TITLE
updated inkscape:version from the old "0.48.2 r9819" to the latest "0.48...

### DIFF
--- a/resources/inkscape_iconfont_canvas_template.svg
+++ b/resources/inkscape_iconfont_canvas_template.svg
@@ -14,7 +14,7 @@
    height="1000"
    id="svg5496"
    sodipodi:version="0.32"
-   inkscape:version="0.48.2 r9819"
+   inkscape:version="0.48.4 r9939"
    sodipodi:docname="inkscape_iconfont_canvas_template.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape">
   <metadata


### PR DESCRIPTION
....4 r9939"

the old version declaration causes an error pop-up saying that something went wrong and it can't open the file.
Upgrading to the new released version of Inkscape all went good.
